### PR TITLE
more environment variable configuration + github access token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ To configure Slack/Teams notifications, create the following configuration optio
     webhook_url='your_webhook_url'
 ```
 
+You may supply the webhook URL via the environment variable `SLACK_WEBHOOK_URL`, and setting the requisite value in `config.toml` to `env`.
+
+Setting Up the Webhook
+----------------------
+
+You may choose to pass the Github webhook secret and host via the environment variables `GITHUB_WEBHOOK_SECRET` and `GITHUB_WEBHOOK_HOST`, and setting the corresponding values in `config.toml` to `env`.
+
 Usage
 =====
 

--- a/config.py
+++ b/config.py
@@ -25,7 +25,11 @@ class WatcherConfig:
             self.access_token = environ.get('GITHUB_WATCHER_TOKEN')
 
         self.webhook = self._config['webhook']
-
+        if self.webhook['secret'] == 'env':
+            self.webhook['secret'] = environ.get('GITHUB_WEBHOOK_SECRET')
+        if self.webhook['host'] == 'env':
+            self.webhook['host'] = environ.get('GITHUB_WEBHOOK_HOST')
+            
         for detector in self._config['detectors']:
             if detector not in AvailableDetectors:
                 logging.error(

--- a/config.toml
+++ b/config.toml
@@ -13,10 +13,10 @@ access_token='env'
     repos = []
 
 [webhook]
-    secret=""
+    secret="env"
     host="0.0.0.0"
 
 [notifiers.console]
 
 [notifiers.slack_webhook]
-    webhook_url=''
+    webhook_url='env'

--- a/notifiers/slack.py
+++ b/notifiers/slack.py
@@ -1,3 +1,5 @@
+from os import environ
+
 from notifiers.notifier import Notifier
 from notifiers import Registry
 import requests
@@ -10,6 +12,9 @@ class SlackWebhookNotifier(Notifier):
             raise Exception("webhook_url not found in config file")
 
         self._webhook_url = config['webhook_url']
+
+        if self._webhook_url == 'env':
+            self._webhook_url = environ.get('SLACK_WEBHOOK_URL')
 
     def process(self, findings, detector_name):
         """Send a list of findings via Slack incoming webhook."""

--- a/processor.py
+++ b/processor.py
@@ -2,6 +2,8 @@ import logging
 import tempfile
 import subprocess
 
+from config import Config
+
 class EventProcessor:
     def __init__(self):
         self.client = None
@@ -32,7 +34,9 @@ class EventProcessor:
             logging.info(
                 'Cloning repository {} into {}'.
                 format(repo_full_name, repo_dir.name))
-            subprocess.run(["git", "clone", repo_url, repo_dir.name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if Config.access_token:
+                repo_url_with_token = repo_url.replace("https://", "https://git:" + Config.access_token + "@")
+            subprocess.run(["git", "clone", repo_url_with_token, repo_dir.name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             self.repo_cache[repo_url] = repo_dir
             # we haven't cloned this repository yet, so we don't have a baseline
             logging.info(


### PR DESCRIPTION
this patch allows for the pulling of repositories available under the scope of the token's user by modifying the `git clone` request to include the provided access token as basic authentication, especially helpful in the `webhook` implementation.  it also allows for the configuration of other seemingly sensitive variables to be passed along as environment variables.